### PR TITLE
Fix https unsafe content

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,4 +1,4 @@
-baseurl = "http://methane.github.io"
+baseurl = "https://methane.github.io"
 languageCode = "en-us"
 title = "Python Bytes"
 disqusShortname = "pythonbyte"


### PR DESCRIPTION
![withouthttps](http://cl.natw.me/Zr9O/d)

Because you have your site url set as http://... your page looks very bad when viewed with https.

I proposed the shorter solution of just always loading your resources from https. Other solutions that would work include removing  `.Site.BaseUrl` from your header and footer partials, or possibly just removing the protocol from `.Site.BaseUrl`.
